### PR TITLE
Add location to comment

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ var commitPrefix = func() string {
 	if prefix := os.Getenv("GIT_EXEC_COMMIT_PREFIX"); prefix != "" {
 		return prefix
 	}
-	return "🤖 %s $"
+	return "🤖 [%s] $"
 }()
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -77,6 +77,14 @@ func splitArgsToEnvsAndCommand(args []string) ([]string, []string) {
 }
 
 func buildCommitMessage(envs []string, commandArgs []string, outBuf *bytes.Buffer) string {
+	firstLine := buildCommitMessageFirstLine(envs, commandArgs)
+	return fmt.Sprintf("%s\n\n%s\n",
+		firstLine,
+		outBuf.String(),
+	)
+}
+
+func buildCommitMessageFirstLine(envs []string, commandArgs []string) string {
 	commandParts := make([]string, len(commandArgs))
 	for i, arg := range commandArgs {
 		if strings.Contains(arg, " ") && !(strings.HasPrefix(arg, "'") && strings.HasSuffix(arg, "'")) {
@@ -86,10 +94,9 @@ func buildCommitMessage(envs []string, commandArgs []string, outBuf *bytes.Buffe
 		}
 	}
 
-	return fmt.Sprintf("%s %s %s\n\n%s\n",
+	return fmt.Sprintf("%s %s %s",
 		commitPrefix,
 		strings.Join(envs, " "),
 		strings.Join(commandParts, " "),
-		outBuf.String(),
 	)
 }

--- a/main.go
+++ b/main.go
@@ -48,22 +48,9 @@ func main() {
 		return
 	}
 
-	commandParts := make([]string, len(commandArgs))
-	for i, arg := range commandArgs {
-		if strings.Contains(arg, " ") && !(strings.HasPrefix(arg, "'") && strings.HasSuffix(arg, "'")) {
-			commandParts[i] = fmt.Sprintf("'%s'", arg)
-		} else {
-			commandParts[i] = arg
-		}
-	}
-
 	// 3. "git commit" を以下のオプションと標準力を指定して実行する。
-	commitMessage := fmt.Sprintf("%s %s %s\n\n%s\n",
-		commitPrefix,
-		strings.Join(envs, " "),
-		strings.Join(commandParts, " "),
-		outBuf.String(),
-	)
+	commitMessage := buildCommitMessage(envs, commandArgs, &outBuf)
+
 	// See https://tracpath.com/docs/git-commit/
 	commitCmd := exec.Command("git", "commit", "--file", "-")
 	commitCmd.Stdin = bytes.NewBufferString(commitMessage)
@@ -87,4 +74,22 @@ func splitArgsToEnvsAndCommand(args []string) ([]string, []string) {
 		}
 	}
 	return envs, command
+}
+
+func buildCommitMessage(envs []string, commandArgs []string, outBuf *bytes.Buffer) string {
+	commandParts := make([]string, len(commandArgs))
+	for i, arg := range commandArgs {
+		if strings.Contains(arg, " ") && !(strings.HasPrefix(arg, "'") && strings.HasSuffix(arg, "'")) {
+			commandParts[i] = fmt.Sprintf("'%s'", arg)
+		} else {
+			commandParts[i] = arg
+		}
+	}
+
+	return fmt.Sprintf("%s %s %s\n\n%s\n",
+		commitPrefix,
+		strings.Join(envs, " "),
+		strings.Join(commandParts, " "),
+		outBuf.String(),
+	)
 }

--- a/main.go
+++ b/main.go
@@ -94,9 +94,12 @@ func buildCommitMessageFirstLine(envs []string, commandArgs []string) string {
 		}
 	}
 
-	return fmt.Sprintf("%s %s %s",
+	parts := []string{
 		commitPrefix,
-		strings.Join(envs, " "),
-		strings.Join(commandParts, " "),
-	)
+	}
+	if len(envs) > 0 {
+		parts = append(parts, strings.Join(envs, " "))
+	}
+	parts = append(parts, strings.Join(commandParts, " "))
+	return strings.Join(parts, " ")
 }

--- a/main.go
+++ b/main.go
@@ -126,7 +126,9 @@ func buildCommitMessageHead() (string, error) {
 	}
 
 	var location string
-	if strings.HasPrefix(relPath, "./") {
+	if relPath == "." {
+		location = rootDirName
+	} else if strings.HasPrefix(relPath, "./") {
 		location = rootDirName + relPath[1:]
 	} else if strings.HasPrefix(relPath, "/") {
 		location = relPath

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ var commitPrefix = func() string {
 	if prefix := os.Getenv("GIT_EXEC_COMMIT_PREFIX"); prefix != "" {
 		return prefix
 	}
-	return "🤖 [%s] $"
+	return "🤖 @%s $"
 }()
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -128,8 +128,10 @@ func buildCommitMessageHead() (string, error) {
 	var location string
 	if strings.HasPrefix(relPath, "./") {
 		location = rootDirName + relPath[1:]
-	} else {
+	} else if strings.HasPrefix(relPath, "/") {
 		location = relPath
+	} else {
+		location = rootDirName + "/" + relPath
 	}
 
 	return fmt.Sprintf(commitPrefix, location), nil


### PR DESCRIPTION
`%s` in `GIT_EXEC_COMMIT_PREFIX` is replaced to the location where the command is executed.
The default value of `GIT_EXEC_COMMIT_PREFIX` is `🤖 @%s $` at this time.