### PR TITLE
Show output on executing

### DIFF
--- a/command.go
+++ b/command.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -23,11 +25,13 @@ func newCommand(args []string) *Command {
 func (c *Command) Run() error {
 	cmd := exec.Command(c.Args[0], c.Args[1:]...)
 	cmd.Env = append(os.Environ(), c.Envs...)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
+	var buf bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &buf)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &buf)
+	if err := cmd.Run(); err != nil {
 		return err
 	}
-	c.Output = string(output)
+	c.Output = buf.String()
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -55,8 +55,6 @@ func main() {
 		return
 	}
 
-	fmt.Println(command.Output)
-
 	uncommitedChanges, err := hasUncommittedChanges()
 	if err != nil {
 		fmt.Printf("git diff failed: %+v\n", err)

--- a/main.go
+++ b/main.go
@@ -55,6 +55,8 @@ func main() {
 		return
 	}
 
+	fmt.Println(command.Output)
+
 	uncommitedChanges, err := hasUncommittedChanges()
 	if err != nil {
 		fmt.Printf("git diff failed: %+v\n", err)

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package main
 
 import "fmt"
 
-const Version = "0.0.7"
+const Version = "0.0.8"
 
 func showVersion() {
 	fmt.Println(Version)


### PR DESCRIPTION
Use `io.MultiWriter` to write the command output to both of buffer and stdout/stderr .