### PR TITLE
Commit message template

### DIFF
--- a/commit_message.go
+++ b/commit_message.go
@@ -17,12 +17,12 @@ type commitMessage struct {
 }
 
 func newCommitMessage(command *Command) *commitMessage {
-	commandParts := make([]string, len(command.Args))
+	argParts := make([]string, len(command.Args))
 	for i, arg := range command.Args {
 		if strings.Contains(arg, " ") && !(strings.HasPrefix(arg, "'") && strings.HasSuffix(arg, "'")) {
-			commandParts[i] = fmt.Sprintf("'%s'", arg)
+			argParts[i] = fmt.Sprintf("'%s'", arg)
 		} else {
-			commandParts[i] = arg
+			argParts[i] = arg
 		}
 	}
 
@@ -30,6 +30,8 @@ func newCommitMessage(command *Command) *commitMessage {
 	if len(command.Envs) > 0 {
 		envs = append(envs, strings.Join(command.Envs, " "))
 	}
+
+	commandParts := append(envs, argParts...)
 
 	return &commitMessage{
 		Env:     strings.Join(envs, " "),
@@ -64,5 +66,5 @@ func (m *commitMessage) Build() (string, error) {
 		return "", err
 	}
 
-	return buf.String(), nil
+	return strings.TrimSpace(buf.String()), nil
 }

--- a/commit_message.go
+++ b/commit_message.go
@@ -1,32 +1,44 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"text/template"
 )
 
-var commitPrefix = func() string {
-	if prefix := os.Getenv("GIT_EXEC_COMMIT_PREFIX"); prefix != "" {
-		return prefix
-	}
-	return "🤖 @%s $"
-}()
+type commitMessage struct {
+	Env      string
+	Emoji    string
+	Location string
+	Prompt   string
+	Command  string
+	Body     string
+}
 
-func buildCommitMessage(command *Command) string {
-	firstLine := buildCommitMessageFirstLine(command.Envs, command.Args)
-	if command.Output == "" {
-		return firstLine
-	} else {
-		return fmt.Sprintf("%s\n\n%s\n", firstLine, command.Output)
+func newCommitMessage(location, env, command string) *commitMessage {
+	return &commitMessage{
+		Env:      env,
+		Emoji:    getEnvString("GIT_EXEC_EMOJI", "🤖"),
+		Location: location,
+		Prompt:   getEnvString("GIT_EXEC_PROMPT", "$"),
+		Command:  command,
 	}
 }
 
-func buildCommitMessageFirstLine(envs []string, commandArgs []string) string {
-	commandParts := make([]string, len(commandArgs))
-	for i, arg := range commandArgs {
+const defaultHeadTemplateSurce = `{{.Emoji}} @{{.Location}} {{.Prompt}} {{.Command}}`
+
+func newTemplate() (*template.Template, error) {
+	source := getEnvString("GIT_EXEC_TEMPLATE", defaultHeadTemplateSurce)
+	return template.New("commitMessage").Parse(source + "\n\n{{.Body}}\n")
+}
+
+func buildCommitMessage(command *Command) (string, error) {
+	commandParts := make([]string, len(command.Args))
+	for i, arg := range command.Args {
 		if strings.Contains(arg, " ") && !(strings.HasPrefix(arg, "'") && strings.HasSuffix(arg, "'")) {
 			commandParts[i] = fmt.Sprintf("'%s'", arg)
 		} else {
@@ -34,21 +46,33 @@ func buildCommitMessageFirstLine(envs []string, commandArgs []string) string {
 		}
 	}
 
-	head, err := buildCommitMessageHead()
+	location, err := getLocation()
 	if err != nil {
-		fmt.Printf("Failed to build commit prefix: %+v\n", err)
-		panic(err)
+		return "", err
 	}
 
-	parts := []string{head}
-	if len(envs) > 0 {
-		parts = append(parts, strings.Join(envs, " "))
+	envs := []string{}
+	if len(command.Envs) > 0 {
+		envs = append(envs, strings.Join(command.Envs, " "))
 	}
-	parts = append(parts, strings.Join(commandParts, " "))
-	return strings.Join(parts, " ")
+
+	msg := newCommitMessage(location, strings.Join(envs, " "), strings.Join(commandParts, " "))
+	msg.Body = command.Output
+
+	tmpl, err := newTemplate()
+	if err != nil {
+		return "", err
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := tmpl.Execute(buf, msg); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
 }
 
-func buildCommitMessageHead() (string, error) {
+func getLocation() (string, error) {
 	curDir, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -64,18 +88,15 @@ func buildCommitMessageHead() (string, error) {
 		return "", err
 	}
 
-	var location string
 	if relPath == "." {
-		location = rootDirName
+		return rootDirName, nil
 	} else if strings.HasPrefix(relPath, "./") {
-		location = rootDirName + relPath[1:]
+		return rootDirName + relPath[1:], nil
 	} else if strings.HasPrefix(relPath, "/") {
-		location = relPath
+		return relPath, nil
 	} else {
-		location = rootDirName + "/" + relPath
+		return rootDirName + "/" + relPath, nil
 	}
-
-	return fmt.Sprintf(commitPrefix, location), nil
 }
 
 func gitRootDir() (string, error) {

--- a/commit_message.go
+++ b/commit_message.go
@@ -3,9 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"text/template"
 )
@@ -51,7 +48,7 @@ func (*commitMessage) newTemplate() (*template.Template, error) {
 }
 
 func (m *commitMessage) Build() (string, error) {
-	location, err := m.getLocation()
+	location, err := getLocation()
 	if err != nil {
 		return "", err
 	}
@@ -68,39 +65,4 @@ func (m *commitMessage) Build() (string, error) {
 	}
 
 	return buf.String(), nil
-}
-
-func (*commitMessage) getLocation() (string, error) {
-	curDir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	rootDir, err := gitRootDir()
-	if err != nil {
-		return "", err
-	}
-	rootDirName := filepath.Base(rootDir)
-
-	relPath, err := filepath.Rel(rootDir, curDir)
-	if err != nil {
-		return "", err
-	}
-
-	if relPath == "." {
-		return rootDirName, nil
-	} else if strings.HasPrefix(relPath, "./") {
-		return rootDirName + relPath[1:], nil
-	} else if strings.HasPrefix(relPath, "/") {
-		return relPath, nil
-	} else {
-		return rootDirName + "/" + relPath, nil
-	}
-}
-
-func gitRootDir() (string, error) {
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
 }

--- a/commit_message.go
+++ b/commit_message.go
@@ -45,34 +45,32 @@ func newCommitMessage(command *Command) *commitMessage {
 
 const defaultHeadTemplateSurce = `{{.Emoji}} @{{.Location}} {{.Prompt}} {{.Command}}`
 
-func newTemplate() (*template.Template, error) {
+func (*commitMessage) newTemplate() (*template.Template, error) {
 	source := getEnvString("GIT_EXEC_TEMPLATE", defaultHeadTemplateSurce)
 	return template.New("commitMessage").Parse(source + "\n\n{{.Body}}\n")
 }
 
-func buildCommitMessage(command *Command) (string, error) {
-	location, err := getLocation()
+func (m *commitMessage) Build() (string, error) {
+	location, err := m.getLocation()
 	if err != nil {
 		return "", err
 	}
+	m.Location = location
 
-	msg := newCommitMessage(command)
-	msg.Location = location
-
-	tmpl, err := newTemplate()
+	tmpl, err := m.newTemplate()
 	if err != nil {
 		return "", err
 	}
 
 	buf := bytes.NewBuffer(nil)
-	if err := tmpl.Execute(buf, msg); err != nil {
+	if err := tmpl.Execute(buf, m); err != nil {
 		return "", err
 	}
 
 	return buf.String(), nil
 }
 
-func getLocation() (string, error) {
+func (*commitMessage) getLocation() (string, error) {
 	curDir, err := os.Getwd()
 	if err != nil {
 		return "", err

--- a/commit_message_test.go
+++ b/commit_message_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitMessage(t *testing.T) {
+	type pattern struct {
+		name     string
+		expected string
+		location string
+		emoji    string
+		prompt   string
+		template string
+		envs     []string
+		args     []string
+		output   string
+	}
+
+	type option = func(*pattern)
+	location := func(v string) option { return func(p *pattern) { p.location = v } }
+	emoji := func(v string) option { return func(p *pattern) { p.emoji = v } }
+	prompt := func(v string) option { return func(p *pattern) { p.prompt = v } }
+	template := func(v string) option { return func(p *pattern) { p.template = v } }
+	envs := func(v []string) option { return func(p *pattern) { p.envs = v } }
+	args := func(v []string) option { return func(p *pattern) { p.args = v } }
+	output := func(v string) option { return func(p *pattern) { p.output = v } }
+
+	newPattern := func(name, expected string, opts ...option) pattern {
+		p := pattern{
+			name:     name,
+			expected: expected,
+			location: "root",
+		}
+		for _, opt := range opts {
+			opt(&p)
+		}
+		return p
+	}
+
+	patterns := []pattern{
+		newPattern("the most simple pattern", "🤖 @root $ cmd1", args([]string{"cmd1"})),
+		newPattern("with location", "🤖 @root/sub1 $ cmd1", location("root/sub1"), args([]string{"cmd1"})),
+		newPattern("with envs", "🤖 @root $ key1=val1 key2=val2 key3=val3 cmd1", args([]string{"cmd1"}),
+			envs([]string{"key1=val1", "key2=val2", "key3=val3"}),
+		),
+		newPattern("with output", "🤖 @root $ cmd1\n\noutput1", args([]string{"cmd1"}), output("output1")),
+		newPattern("with multiple lines output", "🤖 @root $ cmd1\n\noutput1\noutput2", args([]string{"cmd1"}), output("output1\noutput2")),
+		newPattern("with arguments", "🤖 @root $ cmd1 foo bar", args([]string{"cmd1", "foo", "bar"})),
+		newPattern("with emoji", "🏭 @root $ cmd1", emoji("🏭"), args([]string{"cmd1"})),
+		newPattern("with prompt", "🤖 @root % cmd1", prompt("%"), args([]string{"cmd1"})),
+		newPattern("with template", "🤖 $ cmd1 [root]", args([]string{"cmd1"}),
+			template("{{.Emoji}} {{.Prompt}} {{.Command}} [{{.Location}}]"),
+		),
+		newPattern("with template and multiple lines output", "🤖 $ cmd1 [root]\n\noutput1\noutput2", args([]string{"cmd1"}),
+			output("output1\noutput2"),
+			template("{{.Emoji}} {{.Prompt}} {{.Command}} [{{.Location}}]"),
+		),
+	}
+
+	setEnvTemporarily := func(key, value string) func() {
+		var setBackup func()
+		backup := os.Getenv(key)
+		if backup == "" {
+			setBackup = func() { os.Unsetenv(key) }
+		} else {
+			setBackup = func() { os.Setenv(key, backup) }
+		}
+		if value == "" {
+			os.Unsetenv(key)
+		} else {
+			os.Setenv(key, value)
+		}
+		return setBackup
+	}
+
+	for _, ptn := range patterns {
+		t.Run(ptn.name, func(t *testing.T) {
+			defer setEnvTemporarily("GIT_EXEC_EMOJI", ptn.emoji)()
+			defer setEnvTemporarily("GIT_EXEC_PROMPT", ptn.prompt)()
+			defer setEnvTemporarily("GIT_EXEC_TEMPLATE", ptn.template)()
+
+			var bkGetLocation func() (string, error)
+			getLocation, bkGetLocation = func() (string, error) { return ptn.location, nil }, getLocation
+			defer func() { getLocation = bkGetLocation }()
+
+			command := &Command{Envs: ptn.envs, Args: ptn.args, Output: ptn.output}
+			commitMsg := newCommitMessage(command)
+
+			actual, err := commitMsg.Build()
+			assert.NoError(t, err)
+			assert.Equal(t, ptn.expected, actual)
+		})
+	}
+}

--- a/env.go
+++ b/env.go
@@ -14,3 +14,11 @@ func getEnvBool(key string) bool {
 		return false
 	}
 }
+
+func getEnvString(key string, defaultValue string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultValue
+	}
+	return v
+}

--- a/location.go
+++ b/location.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+func getLocation() (string, error) {
+	curDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	rootDir, err := gitRootDir()
+	if err != nil {
+		return "", err
+	}
+	rootDirName := filepath.Base(rootDir)
+
+	relPath, err := filepath.Rel(rootDir, curDir)
+	if err != nil {
+		return "", err
+	}
+
+	if relPath == "." {
+		return rootDirName, nil
+	} else if strings.HasPrefix(relPath, "./") {
+		return rootDirName + relPath[1:], nil
+	} else if strings.HasPrefix(relPath, "/") {
+		return relPath, nil
+	} else {
+		return rootDirName + "/" + relPath, nil
+	}
+}
+
+func gitRootDir() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/location.go
+++ b/location.go
@@ -7,7 +7,11 @@ import (
 	"strings"
 )
 
-func getLocation() (string, error) {
+type locationFunc func() (string, error)
+
+var getLocation locationFunc = getLocationFromGitRoot
+
+func getLocationFromGitRoot() (string, error) {
 	curDir, err := os.Getwd()
 	if err != nil {
 		return "", err

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 	}
 
 	// 3. "git commit" を以下のオプションと標準力を指定して実行する。
-	commitMessage, err := buildCommitMessage(command)
+	commitMessage, err := newCommitMessage(command).Build()
 	if err != nil {
 		fmt.Printf("Failed to build commit message: %+v\n", err)
 		return

--- a/main.go
+++ b/main.go
@@ -86,7 +86,11 @@ func main() {
 	}
 
 	// 3. "git commit" を以下のオプションと標準力を指定して実行する。
-	commitMessage := buildCommitMessage(command)
+	commitMessage, err := buildCommitMessage(command)
+	if err != nil {
+		fmt.Printf("Failed to build commit message: %+v\n", err)
+		return
+	}
 
 	// See https://tracpath.com/docs/git-commit/
 	commitCmd := exec.Command("git", "commit", "--file", "-")

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package main
 
 import "fmt"
 
-const Version = "0.0.10"
+const Version = "0.0.11"
 
 func showVersion() {
 	fmt.Println(Version)


### PR DESCRIPTION
- Environment variable `GIT_EXEC_TEMPLATE`  is used to overwrite message template if given
- Extract `commitMessage` type to ease testing
- Define getLocation as a variable of function to ease testing
