### PR TITLE
Use square brackets instead of @ for location

### DIFF
--- a/commit_message.go
+++ b/commit_message.go
@@ -42,7 +42,7 @@ func newCommitMessage(command *Command) *commitMessage {
 	}
 }
 
-const defaultHeadTemplateSurce = `{{.Emoji}} @{{.Location}} {{.Prompt}} {{.Command}}`
+const defaultHeadTemplateSurce = `{{.Emoji}} [{{.Location}}] {{.Prompt}} {{.Command}}`
 
 func (*commitMessage) newTemplate() (*template.Template, error) {
 	source := getEnvString("GIT_EXEC_TEMPLATE", defaultHeadTemplateSurce)

--- a/guard.go
+++ b/guard.go
@@ -14,16 +14,16 @@ func isGuardError(err error) bool {
 }
 
 func guard() error {
-	// 環境変数 GIT_EXEC_SKIP_GUARD, GIT_EXEC_SKIP_GUARD_UNCOMMITED_CHANGES, GIT_EXEC_SKIP_GUARD_UNTRACKED_FILES には
+	// 環境変数 GIT_EXEC_SKIP_GUARD, GIT_EXEC_SKIP_GUARD_UNCOMMITTED_CHANGES, GIT_EXEC_SKIP_GUARD_UNTRACKED_FILES には
 	// 以下の値で真偽値を表す文字列を想定する
 	// true: "true", "1", "yes", "on"
 	// false: "false", "0", "no", "off"
 	// 空文字列 あるいは それ以外の文字列は false として扱う
 	//
-	// GIT_EXEC_SKIP_GUARD あるいは GIT_EXEC_SKIP_GUARD_UNCOMMITED_CHANGES のいずれかが true でなければ、コミットされていない変更があればエラーを返す
+	// GIT_EXEC_SKIP_GUARD あるいは GIT_EXEC_SKIP_GUARD_UNCOMMITTED_CHANGES のいずれかが true でなければ、コミットされていない変更があればエラーを返す
 	// GIT_EXEC_SKIP_GUARD あるいは GIT_EXEC_SKIP_GUARD_UNTRACKED_FILES のいずれかが true でなければ、追跡されていないファイルがあればエラーを返す
 
-	if err := guardUncommitedChanges(); err != nil {
+	if err := guardUncommittedChanges(); err != nil {
 		return err
 	}
 	if err := guardUntrackedFiles(); err != nil {
@@ -33,8 +33,8 @@ func guard() error {
 	return nil
 }
 
-func guardUncommitedChanges() error {
-	if getEnvBool("GIT_EXEC_SKIP_GUARD") || getEnvBool("GIT_EXEC_SKIP_GUARD_UNCOMMITED_CHANGES") {
+func guardUncommittedChanges() error {
+	if getEnvBool("GIT_EXEC_SKIP_GUARD") || getEnvBool("GIT_EXEC_SKIP_GUARD_UNCOMMITTED_CHANGES") {
 		return nil
 	}
 	diff, err := hasUncommittedChanges()


### PR DESCRIPTION
Modify default commit message template.
Because `@foo` would become a mention on github even in commit message ( `@foo/bar` is ok ) .
