### PR TITLE
Improve help message

### DIFF
--- a/help.go
+++ b/help.go
@@ -33,6 +33,10 @@ func help() {
 			item = fmt.Sprintf("%s%s, "+longNameFormat, indent, opt.ShortName, opt.LongName)
 		}
 		item += " " + optionMessageMap[opt.LongName]
+		if defaultGetter, ok := defaultValueGetterMap[opt.LongName]; ok {
+			item += fmt.Sprintf(" (default: %s)", defaultGetter())
+		}
+
 		optionItems[i] = item
 		if !opt.WithoutEnv {
 			envVarItems = append(envVarItems, fmt.Sprintf(longNameFormat+" %s", opt.LongName, opt.envKey()))
@@ -57,3 +61,28 @@ var optionMessageMap = map[string]string{
 	"--skip-guard-uncommitted-changes": "Skip the guard check for uncommitted changes before executing command.",
 	"--skip-guard-untracked-files":     "Skip the guard check for untracked files before executing command.",
 }
+
+var defaultValueGetterMap = func() map[string]func() string {
+	boolToString := func(b bool) string {
+		if b {
+			return "true"
+		} else {
+			return "false"
+		}
+	}
+	quote := func(s string) string {
+		return fmt.Sprintf("%q", s)
+	}
+
+	o := defaultOptions
+	return map[string]func() string{
+		"--directory": func() string { return quote(o.Directory) },
+		"--emoji":     func() string { return quote(o.Emoji) },
+		"--prompt":    func() string { return quote(o.Prompt) },
+		"--template":  func() string { return quote(o.Template) },
+		// skip guard
+		"--skip-guard":                     func() string { return boolToString(o.SkipGuard) },
+		"--skip-guard-uncommitted-changes": func() string { return boolToString(o.SkipGuardUncommittedChanges) },
+		"--skip-guard-untracked-files":     func() string { return boolToString(o.SkipGuardUntrackedFiles) },
+	}
+}()

--- a/help.go
+++ b/help.go
@@ -1,17 +1,59 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 func help() {
-	// git-exec は <command>よりも前に 複数のキーと値の組み合わせを指定可能で、
-	// <command> 以後は 複数の引数を指定可能です。
-	fmt.Printf(`Usage: git-exec [key=value ...] <command> [args ...])
-
-Examples:
+	firstLine := `Usage: git-exec [options ...] [key=value ...] <command> [args ...]`
+	examples := `Examples:
 * Specify environment variables.
 	git-exec FOO=fooooo make args1 args2
 
 * Use shell to work with redirect operator.
 	git-exec /bin/bash -c 'echo "foo" >> README.md'
-`)
+`
+	indent := "  "
+	optionItems := make([]string, len(optionTypes))
+	maxLongNameLength := 0
+	for _, opt := range optionTypes {
+		if maxLongNameLength < len(opt.LongName) {
+			maxLongNameLength = len(opt.LongName)
+		}
+	}
+
+	envVarItems := []string{}
+	longNameFormat := "%-" + fmt.Sprintf("%ds", maxLongNameLength)
+	for i, opt := range optionTypes {
+		var item string
+		if opt.ShortName == "" {
+			item = fmt.Sprintf("%s    "+longNameFormat, indent, opt.LongName)
+		} else {
+			item = fmt.Sprintf("%s%s, "+longNameFormat, indent, opt.ShortName, opt.LongName)
+		}
+		item += " " + optionMessageMap[opt.LongName]
+		optionItems[i] = item
+		if !opt.WithoutEnv {
+			envVarItems = append(envVarItems, fmt.Sprintf(longNameFormat+" %s", opt.LongName, opt.envKey()))
+		}
+	}
+	options := "Options:\n" + strings.Join(optionItems, "\n")
+	envVars := "Environment variable mapping:\n" + strings.Join(envVarItems, "\n")
+
+	// git-exec は <command>よりも前に 複数のキーと値の組み合わせを指定可能で、
+	// <command> 以後は 複数の引数を指定可能です。
+	fmt.Println(firstLine + "\n\n" + options + "\n\n" + envVars + "\n\n" + examples)
+}
+
+var optionMessageMap = map[string]string{
+	"--help":                           "Show this message.",
+	"--version":                        "Show version.",
+	"--directory":                      "Specify the directory where the command is executed.",
+	"--emoji":                          "Specify the emoji used in commit message.",
+	"--prompt":                         "Specify the prompt used in commit message.",
+	"--template":                       "Specify the template to build commit message.",
+	"--skip-guard":                     "Skip the guard check for uncommitted changes and untracked files before executing command.",
+	"--skip-guard-uncommitted-changes": "Skip the guard check for uncommitted changes before executing command.",
+	"--skip-guard-untracked-files":     "Skip the guard check for untracked files before executing command.",
 }

--- a/options.go
+++ b/options.go
@@ -75,8 +75,6 @@ var defaultOptions = &Options{
 }
 
 var (
-	optHelp      = newOptionType("-h", "--help", false, func(o *Options, _ string) { o.Help = true }).withoutEnv()
-	optVersion   = newOptionType("-v", "--version", false, func(o *Options, _ string) { o.Version = true }).withoutEnv()
 	optDirectory = newOptionType("-C", "--directory", true, func(o *Options, v string) { o.Directory = v }).withoutEnv()
 	optEmoji     = newOptionType("-e", "--emoji", true, func(o *Options, v string) { o.Emoji = v })
 	optPrompt    = newOptionType("-p", "--prompt", true, func(o *Options, v string) { o.Prompt = v })
@@ -85,11 +83,12 @@ var (
 	optSkipGuard                   = newOptionType("", "--skip-guard", false, func(o *Options, _ string) { o.SkipGuard = true })
 	optSkipGuardUncommittedChanges = newOptionType("", "--skip-guard-uncommitted-changes", false, func(o *Options, _ string) { o.SkipGuardUncommittedChanges = true })
 	optSkipGuardUntrackedFiles     = newOptionType("", "--skip-guard-untracked-files", false, func(o *Options, _ string) { o.SkipGuardUntrackedFiles = true })
+
+	optHelp    = newOptionType("-h", "--help", false, func(o *Options, _ string) { o.Help = true }).withoutEnv()
+	optVersion = newOptionType("-v", "--version", false, func(o *Options, _ string) { o.Version = true }).withoutEnv()
 )
 
 var optionTypes = []*OptionType{
-	optHelp,
-	optVersion,
 	optDirectory,
 	optEmoji,
 	optPrompt,
@@ -97,6 +96,8 @@ var optionTypes = []*OptionType{
 	optSkipGuard,
 	optSkipGuardUncommittedChanges,
 	optSkipGuardUntrackedFiles,
+	optHelp,
+	optVersion,
 }
 
 var optionKeyMap = func() map[string]*OptionType {

--- a/options.go
+++ b/options.go
@@ -23,7 +23,7 @@ func newOptions() *Options {
 	defaultOptionsCopy := *defaultOptions
 	r := &defaultOptionsCopy
 	for _, opt := range optionTypes {
-		if !opt.HasValue || opt.WithoutEnv {
+		if opt.WithoutEnv {
 			continue
 		}
 		if v := os.Getenv(opt.envKey()); v != "" {
@@ -75,8 +75,8 @@ var defaultOptions = &Options{
 }
 
 var (
-	optHelp      = newOptionType("-h", "--help", false, func(o *Options, _ string) { o.Help = true })
-	optVersion   = newOptionType("-v", "--version", false, func(o *Options, _ string) { o.Version = true })
+	optHelp      = newOptionType("-h", "--help", false, func(o *Options, _ string) { o.Help = true }).withoutEnv()
+	optVersion   = newOptionType("-v", "--version", false, func(o *Options, _ string) { o.Version = true }).withoutEnv()
 	optDirectory = newOptionType("-C", "--directory", true, func(o *Options, v string) { o.Directory = v }).withoutEnv()
 	optEmoji     = newOptionType("-e", "--emoji", true, func(o *Options, v string) { o.Emoji = v })
 	optPrompt    = newOptionType("-p", "--prompt", true, func(o *Options, v string) { o.Prompt = v })

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package main
 
 import "fmt"
 
-const Version = "0.0.11"
+const Version = "0.0.13"
 
 func showVersion() {
 	fmt.Println(Version)


### PR DESCRIPTION
Show name, default value and mapped environment variable for each option.

### Example

```
$ go run . --help
Usage: git-exec [options ...] [key=value ...] <command> [args ...]

Options:
  -C, --directory                      Specify the directory where the command is executed. (default: "")
  -e, --emoji                          Specify the emoji used in commit message. (default: "🤖")
  -p, --prompt                         Specify the prompt used in commit message. (default: "$")
  -t, --template                       Specify the template to build commit message. (default: "{{.Emoji}} [{{.Location}}] {{.Prompt}} {{.Command}}")
      --skip-guard                     Skip the guard check for uncommitted changes and untracked files before executing command. (default: false)
      --skip-guard-uncommitted-changes Skip the guard check for uncommitted changes before executing command. (default: false)
      --skip-guard-untracked-files     Skip the guard check for untracked files before executing command. (default: false)
  -h, --help                           Show this message.
  -v, --version                        Show version.

Environment variable mapping:
--emoji                          GIT_EXEC_EMOJI
--prompt                         GIT_EXEC_PROMPT
--template                       GIT_EXEC_TEMPLATE
--skip-guard                     GIT_EXEC_SKIP_GUARD
--skip-guard-uncommitted-changes GIT_EXEC_SKIP_GUARD_UNCOMMITTED_CHANGES
--skip-guard-untracked-files     GIT_EXEC_SKIP_GUARD_UNTRACKED_FILES

Examples:
* Specify environment variables.
        git-exec FOO=fooooo make args1 args2

* Use shell to work with redirect operator.
        git-exec /bin/bash -c 'echo "foo" >> README.md'
```
