### PR TITLE
Fix location with directory option

### DIFF
--- a/core/commit_message.go
+++ b/core/commit_message.go
@@ -51,12 +51,6 @@ func (m *commitMessage) newTemplate() (*template.Template, error) {
 }
 
 func (m *commitMessage) Build() (string, error) {
-	location, err := getLocation()
-	if err != nil {
-		return "", err
-	}
-	m.Location = location
-
 	tmpl, err := m.newTemplate()
 	if err != nil {
 		return "", err

--- a/core/commit_message_test.go
+++ b/core/commit_message_test.go
@@ -85,12 +85,9 @@ func TestCommitMessage(t *testing.T) {
 			defer setEnvTemporarily("GIT_EXEC_PROMPT", ptn.prompt)()
 			defer setEnvTemporarily("GIT_EXEC_TEMPLATE", ptn.template)()
 
-			var bkGetLocation func() (string, error)
-			getLocation, bkGetLocation = func() (string, error) { return ptn.location, nil }, getLocation
-			defer func() { getLocation = bkGetLocation }()
-
 			command := &command.Command{Envs: ptn.envs, Args: ptn.args, Output: ptn.output}
 			commitMsg := newCommitMessage(command, newOptions())
+			commitMsg.Location = ptn.location
 
 			actual, err := commitMsg.Build()
 			assert.NoError(t, err)

--- a/core/run.go
+++ b/core/run.go
@@ -37,6 +37,13 @@ func Run(options *Options, commandArgs []string) error {
 			return fmt.Errorf("Command execution failed: %+v\n%s", err, cmd.Output)
 		}
 		commitMessage = newCommitMessage(cmd, options)
+
+		location, err := getLocation()
+		if err != nil {
+			return err
+		}
+		commitMessage.Location = location
+
 		return nil
 	}); err != nil {
 		return err

--- a/tests/scenes/02_subdir/directory_option_test.go
+++ b/tests/scenes/02_subdir/directory_option_test.go
@@ -20,7 +20,7 @@ func TestDirectoryOption(t *testing.T) {
 	require.NoError(t, err)
 
 	commitMessage := stdout(t, "git", "log", "-1", "--pretty=%B")
-	assert.Equal(t, `🤖 [02_subdir] $ make add-one parent-add-two
+	assert.Equal(t, `🤖 [02_subdir/sub1] $ make add-one parent-add-two
 
 `, commitMessage)
 }

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package main
 
 import "fmt"
 
-const Version = "0.1.2"
+const Version = "0.1.3"
 
 func showVersion() {
 	fmt.Println(Version)


### PR DESCRIPTION
Fix location in commit message.
It must be equal to directory option but was root directory because `getLocation` was outside changeDir callback. So this PR makes `getLocation` be called inside changeDir callback.
